### PR TITLE
Use ucf to manage /etc/ldapscripts/ldapscripts.conf

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: https://github.com/gerasiov/ldapscripts
 
 Package: ldapscripts
 Architecture: all
-Depends: ${misc:Depends}, ldap-utils
+Depends: ${misc:Depends}, ldap-utils, ucf
 Recommends: sharutils, pwgen
 Suggests: nslcd
 Description: Add and remove users and groups (stored in a LDAP directory)

--- a/debian/postinst
+++ b/debian/postinst
@@ -4,11 +4,8 @@ set -e
 CONF=/etc/ldapscripts/ldapscripts.conf
 
 if [ "$1" = "configure" ]; then
-    zcat /usr/share/doc/ldapscripts/examples/ldapscripts.conf.gz \
-	 >$CONF.example
-    ucf --three-way $CONF.example $CONF
+    ucf --three-way /usr/share/ldapscripts/ldapscripts.conf $CONF
     ucfr ldapscripts $CONF
-    rm -f $CONF.example
 fi
 
 #DEBHELPER#

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+CONF=/etc/ldapscripts/ldapscripts.conf
+
+if [ "$1" = "configure" ]; then
+    zcat /usr/share/doc/ldapscripts/examples/ldapscripts.conf.gz \
+	 >$CONF.example
+    ucf --three-way $CONF.example $CONF
+    ucfr ldapscripts $CONF
+    rm -f $CONF.example
+fi
+
+#DEBHELPER#

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "purge" ]; then
+    if [ -x "$(which ucf 2>/dev/null)" ]; then
+	ucf --purge /etc/ldapscripts/ldapscripts.conf
+    fi
+    if [ -x "$(which ucfr 2>/dev/null)" ]; then
+	ucfr --purge ldapscripts /etc/ldapscripts/ldapscripts.conf
+    fi
+    rm -f /etc/ldapscripts/ldapscripts.conf
+fi
+
+#DEBHELPER#

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ override_dh_installchangelogs:
 	dh_installchangelogs CHANGELOG
 
 override_dh_installexamples:
-	dh_installexamples etc/*.sample
+	dh_installexamples etc/*.sample etc/ldapscripts.conf
 
 override_dh_fixperm:
 	dh_fixperm --exclude etc/ldapscripts/ldapscripts.passwd

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@ override_dh_auto_install:
 	$(MAKE) install DESTDIR=debian/ldapscripts PREFIX=/usr ETCDIR=/etc/ldapscripts LIBDIR=/usr/share/ldapscripts MANDIR=/usr/share/man
 	cp debian/runtime.debian debian/ldapscripts/usr/share/ldapscripts
 	rm debian/ldapscripts/etc/ldapscripts/*.sample
+	rm debian/ldapscripts/etc/ldapscripts/ldapscripts.conf
 
 override_dh_installdocs:
 	dh_installdocs README TODO

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ override_dh_auto_install:
 	$(MAKE) install DESTDIR=debian/ldapscripts PREFIX=/usr ETCDIR=/etc/ldapscripts LIBDIR=/usr/share/ldapscripts MANDIR=/usr/share/man
 	cp debian/runtime.debian debian/ldapscripts/usr/share/ldapscripts
 	rm debian/ldapscripts/etc/ldapscripts/*.sample
-	rm debian/ldapscripts/etc/ldapscripts/ldapscripts.conf
+	mv debian/ldapscripts/etc/ldapscripts/ldapscripts.conf debian/ldapscripts/usr/share/ldapscripts/
 
 override_dh_installdocs:
 	dh_installdocs README TODO
@@ -16,7 +16,7 @@ override_dh_installchangelogs:
 	dh_installchangelogs CHANGELOG
 
 override_dh_installexamples:
-	dh_installexamples etc/*.sample etc/ldapscripts.conf
+	dh_installexamples etc/*.sample
 
 override_dh_fixperm:
 	dh_fixperm --exclude etc/ldapscripts/ldapscripts.passwd


### PR DESCRIPTION
This change is mainly useful if the config file is modified, and a new version is available in the package. Previously, since the file was managed by dpkg, the user would get a prompt to choose between keeping their changes, or replacing the file with the new packaged version. With ucf, there is also the option to view a 3-way diff of the changes, or to perform a 3-way merge.

This change would also be very useful for the FreedomBox project, because it will allow unattended-upgrades to do automatic upgrades of the ldapscripts package (that would normally be skipped due to the dpkg conffile prompt).
