### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,8 @@ ldapscripts (2.0.8-2) UNRELEASED; urgency=medium
     lines.
   * Wrap long lines in changelog entries: 2.0.7-2.
   * Set upstream metadata fields: Repository.
+  * Remove obsolete fields Contact, Name from debian/upstream/metadata
+    (already present in machine-readable debian/copyright).
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 21 Aug 2019 08:28:28 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ ldapscripts (2.0.8-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Archive, Contact, Name.
   * debian/copyright: use spaces rather than tabs to start continuation
     lines.
+  * Wrap long lines in changelog entries: 2.0.7-2.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 21 Aug 2019 08:28:28 +0000
 
@@ -19,7 +20,8 @@ ldapscripts (2.0.8-1) unstable; urgency=medium
 
 ldapscripts (2.0.7-2) unstable; urgency=medium
 
-  * debian/rules: Fix typo. Thanks Chris Lamb <lamby@debian.org>. (Closes: #834578.)
+  * debian/rules: Fix typo. Thanks Chris Lamb <lamby@debian.org>.
+    (Closes: #834578.)
 
  -- Alexander GQ Gerasiov <gq@debian.org>  Mon, 07 Nov 2016 03:07:25 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,8 @@ ldapscripts (2.0.8-2) UNRELEASED; urgency=medium
   * Use secure URI in debian/watch.
   * Bump debhelper from old 9 to 12.
   * Set upstream metadata fields: Archive, Contact, Name.
+  * debian/copyright: use spaces rather than tabs to start continuation
+    lines.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 21 Aug 2019 08:28:28 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ ldapscripts (2.0.8-2) UNRELEASED; urgency=medium
   * debian/copyright: use spaces rather than tabs to start continuation
     lines.
   * Wrap long lines in changelog entries: 2.0.7-2.
+  * Set upstream metadata fields: Repository.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 21 Aug 2019 08:28:28 +0000
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -9,8 +9,8 @@ License: GPL-2+
 
 Files: debian/
 Copyright: 
-	2005-2007 (c) Pierre Habouzit <madcoder@debian.org>
-	2009-2016 (c) Alexander GQ Gerasiov <gq@debian.org>
+ 	2005-2007 (c) Pierre Habouzit <madcoder@debian.org>
+ 	2009-2016 (c) Alexander GQ Gerasiov <gq@debian.org>
 License: GPL-2+
 
 License: GPL-2+

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,4 @@
 Archive: SourceForge
 Name: ldapscripts
 Contact: Ganaël LAPLANCHE <ganael.laplanche@martymac.com>
+Repository: https://git.code.sf.net/p/ldapscripts/code/

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,4 +1,2 @@
 Archive: SourceForge
-Name: ldapscripts
-Contact: Ganaël LAPLANCHE <ganael.laplanche@martymac.com>
 Repository: https://git.code.sf.net/p/ldapscripts/code/


### PR DESCRIPTION
Fix some issues reported by lintian
* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text.html))
* Wrap long lines in changelog entries: 2.0.7-2. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Set upstream metadata fields: Repository.
* Remove obsolete fields Contact, Name from debian/upstream/metadata (already present in machine-readable debian/copyright).


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ldapscripts/fd565909-184f-412f-bc46-c911d7c010d1.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/fd565909-184f-412f-bc46-c911d7c010d1/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/fd565909-184f-412f-bc46-c911d7c010d1/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/fd565909-184f-412f-bc46-c911d7c010d1/diffoscope)).
