### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Alexander GQ Gerasiov <gq@debian.org>
 Homepage: http://ldapscripts.sourceforge.net/
 Standards-Version: 4.5.1
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 13)
 Vcs-Git: https://github.com/gerasiov/ldapscripts.git
 Vcs-Browser: https://github.com/gerasiov/ldapscripts
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Alexander GQ Gerasiov <gq@debian.org>
 Homepage: http://ldapscripts.sourceforge.net/
-Standards-Version: 4.5.1
+Standards-Version: 4.6.1
 Build-Depends: debhelper-compat (= 13)
 Vcs-Git: https://github.com/gerasiov/ldapscripts.git
 Vcs-Browser: https://github.com/gerasiov/ldapscripts

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Alexander GQ Gerasiov <gq@debian.org>
 Homepage: http://ldapscripts.sourceforge.net/
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Build-Depends: debhelper-compat (= 13)
 Vcs-Git: https://github.com/gerasiov/ldapscripts.git
 Vcs-Browser: https://github.com/gerasiov/ldapscripts

--- a/debian/ldapscripts.lintian-overrides
+++ b/debian/ldapscripts.lintian-overrides
@@ -1,2 +1,2 @@
-ldapscripts: non-standard-file-perm etc/ldapscripts/ldapscripts.passwd 0640 != 0644
+ldapscripts: non-standard-file-perm 0640 != 0644 [etc/ldapscripts/ldapscripts.passwd]
 


### PR DESCRIPTION
Fix some issues reported by lintian

* Update lintian override info format in d/ldapscripts.lintian-overrides on line 1. ([mismatched-override](https://lintian.debian.org/tags/mismatched-override))
* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/f8e93c48-cd0e-41dc-9a6a-a116d2eade9e/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f8e93c48-cd0e-41dc-9a6a-a116d2eade9e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f8e93c48-cd0e-41dc-9a6a-a116d2eade9e/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/f8e93c48-cd0e-41dc-9a6a-a116d2eade9e.